### PR TITLE
Fix Joplin note link substitution

### DIFF
--- a/everlink/everlink.py
+++ b/everlink/everlink.py
@@ -578,7 +578,7 @@ def main():
                     continue
                 # now re-write the link
                 # re-write body with regex
-                body = body.replace(link[1],':/{:s})'.format(n['id']))
+                body = body.replace(link[1],':/{:s}'.format(n['id']))
 
                 # write this back to Joplin
                 j.update_note(note['id'], data={'body': body, 'user_updated_time': n['user_updated_time']})


### PR DESCRIPTION
`link[1]` in line 581 is 2nd capture group in regex `\[([^\]]+)\]\((evernote:\/\/[^)]+)\)` to capture Evernote link url, which does not contain the last right parenthesis.
However it will be substituted with Joplin note id with additional right parenthesis:
![图片](https://user-images.githubusercontent.com/7100178/222881008-9c199ab1-67b1-4d30-b2c2-a2c5c2a649c6.png)
I tried to fix this problem and it seems worked.